### PR TITLE
chore(deps): AJDA-2973 bump keboola.component to 1.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ version = "1.0.0"
 requires-python = ">=3.13"
 
 dependencies = [
-  "keboola.component==1.6.10",
+  "keboola.component==1.11.0",
   "keboola.utils==1.1.0",
   "keboola.http-client==1.0.1",
-  "freezegun==1.5.1",
+  "freezegun==1.5.5",
   "mock==5.2.0",
   "pydantic==2.11.4",
   "dateparser==1.2.1",

--- a/uv.lock
+++ b/uv.lock
@@ -6,24 +6,30 @@ certifi==2025.7.9
     # via requests
 charset-normalizer==3.4.2
     # via requests
+colorama==0.4.6
+    # via pytest
 dateparser==1.2.1
     # via
     #   keboola-wr-writer (pyproject.toml)
     #   keboola-utils
 deprecated==1.2.18
     # via keboola-component
-freezegun==1.5.1
-    # via keboola-wr-writer (pyproject.toml)
+freezegun==1.5.5
+    # via
+    #   keboola-wr-writer (pyproject.toml)
+    #   keboola-vcr
 idna==3.10
     # via requests
 iniconfig==2.1.0
     # via pytest
-keboola-component==1.6.10
+keboola-component==1.11.0
     # via keboola-wr-writer (pyproject.toml)
 keboola-http-client==1.0.1
     # via keboola-wr-writer (pyproject.toml)
 keboola-utils==1.1.0
     # via keboola-wr-writer (pyproject.toml)
+keboola-vcr==0.5.0
+    # via keboola-component
 lxml==6.0.0
     # via webdavclient3
 mock==5.2.0
@@ -51,8 +57,9 @@ pytz==2025.2
     # via
     #   keboola-wr-writer (pyproject.toml)
     #   dateparser
-    #   keboola-component
     #   keboola-utils
+pyyaml==6.0.3
+    # via vcrpy
 regex==2024.11.6
     # via dateparser
 requests==2.32.4
@@ -70,11 +77,17 @@ typing-extensions==4.14.1
     #   typing-inspection
 typing-inspection==0.4.1
     # via pydantic
+tzdata==2026.2
+    # via tzlocal
 tzlocal==5.3.1
     # via dateparser
 urllib3==2.5.0
     # via requests
+vcrpy==8.2.1
+    # via keboola-vcr
 webdavclient3==3.14.6
     # via keboola-wr-writer (pyproject.toml)
 wrapt==1.17.2
-    # via deprecated
+    # via
+    #   deprecated
+    #   vcrpy


### PR DESCRIPTION
## Link to issue
https://linear.app/keboola/issue/AJDA-2973

## Description
Bumps `keboola.component` from `1.6.10` to `1.11.0` and regenerates `uv.lock`. Version 1.11.0 scopes the manifest schema/legacy-columns exclusivity guard to output manifests only, so the component can read input tables that carry both a native `schema` node and legacy `columns`/`metadata` keys.

`freezegun` is bumped `1.5.1` → `1.5.5` as well: 1.11.0 pulls in `keboola-vcr`, which requires `freezegun>=1.5.5`, so the old pin made the dependency set unsatisfiable.

## Justification
Aligns this component with the platform-wide `keboola.component>=1.11.0` rollout (AJDA-2973); unblocks reading typed input tables.

## Plans for Customer Communication
None.

## Impact Analysis
Dependency-only change. Backward compatible — existing manifest precedence rules are preserved. No feature flag. `ruff check` and the full `pytest` suite (11 tests) pass against the bumped dependencies.

## Deployment Plan
Standard CI/CD — image is published from the merge commit and ArgoCD picks it up.

## Rollback Plan
Revert this PR, or roll back to the previous image tag in ArgoGitops.

## Post-Release Support Plan
None.
